### PR TITLE
remove erronous 'byrow' in rot.dist.SO3()

### DIFF
--- a/rotations/R/preliminary.R
+++ b/rotations/R/preliminary.R
@@ -51,7 +51,7 @@ rot.dist.SO3 <- function(x, R2=id.SO3, method='extrinsic' , p=1,...) {
     
     n<-nrow(R1)
     R1<-matrix(R1,n,9)
-    R2<-matrix(R2,n,9,byrow=TRUE)
+    R2<-matrix(R2,n,9)
     
     so3dist<-sqrt(rowSums((R1-R2)^2))^p
     


### PR DESCRIPTION
- the second argument in rot.dist.SO3, R2, was copied to a matrix, but with 'byrow'=TRUE. This would shuffles the entries of the nx9 matrix, leading to undesirable results